### PR TITLE
adjusted requirements.txt to fix dependency issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ pylint==2.3.1
 requests==2.22.0
 six==1.12.0
 soupsieve==1.9.5
-typed-ast==1.4.0
-urllib3==1.26.5
+typed-ast
+urllib3
 wrapt==1.11.2


### PR DESCRIPTION
I noticed when trying to set it up in a virtual environment, it didn't get past installing the requirements.  Both `urllib3` and `typed-ast` had conflicting version numbers.  Taking out the specific version seemed to fix that.